### PR TITLE
Include license in sdists and wheels

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,3 +9,6 @@ testpaths = tests
 max-line-length=120
 exclude = .eggs,.git,bin/*,docs/*,lib/*,examples/*,.venv/,venv/
 inline-quotes = single
+
+[metadata]
+license_file = LICENSE


### PR DESCRIPTION
The MIT license requires also copies of the code include the license.