### PR TITLE
Switch label type

### DIFF
--- a/audiomate/corpus/io/tatoeba.py
+++ b/audiomate/corpus/io/tatoeba.py
@@ -24,7 +24,8 @@ class TatoebaDownloader(base.CorpusDownloader):
           Website
 
     Args:
-        include_languages (list): List of languages to download. If None all are downloaded.
+        include_languages (list): List of languages codes to download. If None all are downloaded.
+                                  Languages: https://github.com/Tatoeba/tatoeba2/blob/dev/src/Lib/LanguagesLib.php#L222
         include_licenses (list): Sentences are downloaded only if their license is in this list.
                                  If None all licenses are included.
         load_empty_license (bool): Sentences with an empty license are not meant to be reused.

--- a/audiomate/corpus/io/tatoeba.py
+++ b/audiomate/corpus/io/tatoeba.py
@@ -172,6 +172,6 @@ class TatoebaReader(base.CorpusReader):
 
             utterance = corpus.new_utterance(idx, idx, speaker_idx)
             utterance.set_label_list(annotations.LabelList.create_single(transcript,
-                                                                         idx=audiomate.corpus.LL_WORD_TRANSCRIPT_RAW))
+                                                                         idx=audiomate.corpus.LL_WORD_TRANSCRIPT))
 
         return corpus


### PR DESCRIPTION
I changed the label type, because this solved a problem i had and the other datasets seemed to have LL_WORD_TRANSCRIPT as default and LL_WORD_TRANSCRIPT_RAW only optionally.