### PR TITLE
Downloader for the Mozilla Common Voice Datasets

### DIFF
--- a/audiomate/corpus/io/__init__.py
+++ b/audiomate/corpus/io/__init__.py
@@ -23,7 +23,7 @@ from .timit import TimitReader  # noqa: F401
 from .swc import SWCDownloader, SWCReader  # noqa: F401
 from .free_spoken_digits import FreeSpokenDigitDownloader, FreeSpokenDigitReader  # noqa: F401
 from .tatoeba import TatoebaDownloader, TatoebaReader  # noqa: F401
-from .common_voice import CommonVoiceReader  # noqa: F401
+from .common_voice import CommonVoiceDownloader, CommonVoiceReader  # noqa: F401
 from .mailabs import MailabsDownloader, MailabsReader  # noqa: F401
 from .rouen import RouenDownloader, RouenReader  # noqa: F401
 from .audio_mnist import AudioMNISTDownloader, AudioMNISTReader  # noqa: F401

--- a/audiomate/corpus/io/common_voice.py
+++ b/audiomate/corpus/io/common_voice.py
@@ -7,6 +7,57 @@ from audiomate import issuers
 from audiomate.corpus import subset
 from audiomate.utils import textfile
 from . import base
+from . import downloader
+
+# DOWNLOAD_URLS taken from https://voice.mozilla.org/de/datasets
+DOWNLOAD_URLS = {
+    'de': 'https://voice-prod-bundler-ee1969a6ce8178826482b88e843c335139bd3fb4.s3.amazonaws.com/cv-corpus-4-2019-12-10/de.tar.gz',  # noqa
+    'en': 'https://voice-prod-bundler-ee1969a6ce8178826482b88e843c335139bd3fb4.s3.amazonaws.com/cv-corpus-4-2019-12-10/en.tar.gz',  # noqa
+    'et': 'https://voice-prod-bundler-ee1969a6ce8178826482b88e843c335139bd3fb4.s3.amazonaws.com/cv-corpus-4-2019-12-10/et.tar.gz',  # noqa
+    'it': 'https://voice-prod-bundler-ee1969a6ce8178826482b88e843c335139bd3fb4.s3.amazonaws.com/cv-corpus-4-2019-12-10/it.tar.gz',  # noqa
+    'fr': 'https://voice-prod-bundler-ee1969a6ce8178826482b88e843c335139bd3fb4.s3.amazonaws.com/cv-corpus-4-2019-12-10/fr.tar.gz',  # noqa
+    'cy': 'https://voice-prod-bundler-ee1969a6ce8178826482b88e843c335139bd3fb4.s3.amazonaws.com/cv-corpus-4-2019-12-10/cy.tar.gz',  # noqa
+    'br': 'https://voice-prod-bundler-ee1969a6ce8178826482b88e843c335139bd3fb4.s3.amazonaws.com/cv-corpus-4-2019-12-10/br.tar.gz',  # noqa
+    'cv': 'https://voice-prod-bundler-ee1969a6ce8178826482b88e843c335139bd3fb4.s3.amazonaws.com/cv-corpus-4-2019-12-10/cv.tar.gz',  # noqa
+    'tr': 'https://voice-prod-bundler-ee1969a6ce8178826482b88e843c335139bd3fb4.s3.amazonaws.com/cv-corpus-4-2019-12-10/tr.tar.gz',  # noqa
+    'tt': 'https://voice-prod-bundler-ee1969a6ce8178826482b88e843c335139bd3fb4.s3.amazonaws.com/cv-corpus-4-2019-12-10/tt.tar.gz',  # noqa
+    'ky': 'https://voice-prod-bundler-ee1969a6ce8178826482b88e843c335139bd3fb4.s3.amazonaws.com/cv-corpus-4-2019-12-10/ky.tar.gz',  # noqa
+    'ga-IE': 'https://voice-prod-bundler-ee1969a6ce8178826482b88e843c335139bd3fb4.s3.amazonaws.com/cv-corpus-4-2019-12-10/ga-IE.tar.gz',  # noqa
+    'kab': 'https://voice-prod-bundler-ee1969a6ce8178826482b88e843c335139bd3fb4.s3.amazonaws.com/cv-corpus-4-2019-12-10/kab.tar.gz',  # noqa
+    'ca': 'https://voice-prod-bundler-ee1969a6ce8178826482b88e843c335139bd3fb4.s3.amazonaws.com/cv-corpus-4-2019-12-10/ca.tar.gz',  # noqa
+    'zh-TW': 'https://voice-prod-bundler-ee1969a6ce8178826482b88e843c335139bd3fb4.s3.amazonaws.com/cv-corpus-4-2019-12-10/zh-TW.tar.gz',  # noqa
+    'sl': 'https://voice-prod-bundler-ee1969a6ce8178826482b88e843c335139bd3fb4.s3.amazonaws.com/cv-corpus-4-2019-12-10/sl.tar.gz',  # noqa
+    'nl': 'https://voice-prod-bundler-ee1969a6ce8178826482b88e843c335139bd3fb4.s3.amazonaws.com/cv-corpus-4-2019-12-10/nl.tar.gz',  # noqa
+    'cnh': 'https://voice-prod-bundler-ee1969a6ce8178826482b88e843c335139bd3fb4.s3.amazonaws.com/cv-corpus-4-2019-12-10/cnh.tar.gz',  # noqa
+    'eo': 'https://voice-prod-bundler-ee1969a6ce8178826482b88e843c335139bd3fb4.s3.amazonaws.com/cv-corpus-4-2019-12-10/eo.tar.gz',  # noqa
+    'fa': 'https://voice-prod-bundler-ee1969a6ce8178826482b88e843c335139bd3fb4.s3.amazonaws.com/cv-corpus-4-2019-12-10/fa.tar.gz'  # noqa
+}
+
+
+class CommonVoiceDownloader(downloader.ArchiveDownloader):
+    """
+    Downloader for the Common Voice Speech Dataset.
+
+    Args:
+      lang (string): Available languages are
+        de|en|et|it|fr|cy|br|cv|tr|tt|ky|ga-IE|kab|ca|zh-TW|sl|nl|cnh|eo|fa
+        See Common Voice dataset Version on download page for the
+        corresponding language to the shortcut
+    num_threads (int): Number of threads to use for download files.
+    """
+
+    def __init__(self, lang='de', num_threads=1):
+        url = DOWNLOAD_URLS[lang]
+
+        super(CommonVoiceDownloader, self).__init__(
+            url,
+            move_files_up=True,
+            num_threads=num_threads
+        )
+
+    @classmethod
+    def type(cls):
+        return 'common-voice'
 
 
 class CommonVoiceReader(base.CorpusReader):

--- a/docs/notes/changelog.rst
+++ b/docs/notes/changelog.rst
@@ -10,6 +10,8 @@ Next Version
 
 * Setup consistent way for logging. (:ref:`logging`):
 
+* Added downloader (:class:`audiomate.corpus.io.CommonVoiceDownloader`) for the `Common Voice Corpora <https://voice.mozilla.org/de/datasets>`
+
 v5.2.0
 ------
 

--- a/docs/reference/io.rst
+++ b/docs/reference/io.rst
@@ -44,7 +44,7 @@ Implementations
   Acoustic Event Dataset            x         x
   AudioMNIST                        x         x
   Broadcast                                   x
-  Common Voice                                x
+  Common Voice                      x         x
   Default                                     x      x
   ESC-50                            x         x
   Free-Spoken-Digit-Dataset         x         x
@@ -90,6 +90,9 @@ Broadcast
 
 Common-Voice
 ^^^^^^^^^^^^
+.. autoclass:: CommonVoiceDownloader
+   :members:
+
 .. autoclass:: CommonVoiceReader
    :members:
 


### PR DESCRIPTION
This 3 commits add support for downloading the Common Voice datasets. All today available languages are supported. If new languages will be added, the provided tests fail or a new release of the Common Voice dataset is available then the DOWNLOAD_URLS need to be modified to include/replace the new/broken URL's.
- Hopefully the commit message is OK
- flake8 gives no errors
- Docstring is added to the Downloader Class
- Used ArchivDownloader as Base so Downloader is tested
-> ~~Dataset availability tests (checks if HTTP HEAD Status Code is 200) are added~~
- Is straight with master
