### PR TITLE
Added file existence check to CorpusReader ABC - Fixes #89

### DIFF
--- a/audiomate/corpus/io/base.py
+++ b/audiomate/corpus/io/base.py
@@ -97,8 +97,12 @@ class CorpusReader(metaclass=abc.ABCMeta):
             Corpus: The loaded corpus
 
         Raises:
+            IOError: When the provided path does not exist.
             IOError: When the data set is invalid, for example because required files (annotations, …) are missing.
         """
+        if not os.path.exists(path):
+            raise IOError('Invalid path provided: {} not found'.format(path))
+
         # Check for missing files
         missing_files = self._check_for_missing_files(path)
 

--- a/tests/corpus/io/test_base.py
+++ b/tests/corpus/io/test_base.py
@@ -40,3 +40,31 @@ class TestCorpusDownloader:
 
         with pytest.raises(IOError):
             corpus_dl.download(target_folder, force_redownload=False)
+
+
+def create_mock_corpus_reader():
+
+    class MockCorpusReader(base.CorpusReader):
+
+        @classmethod
+        def type(cls):
+            return 'mock'
+
+        def _load(self, path):
+            return
+
+        def _check_for_missing_files(self, path):
+            return []
+
+    return MockCorpusReader()
+
+
+class TestCorpusReader:
+
+    def test_invalid_path_forces_io_error(self, tmpdir):
+        target_folder = tmpdir.strpath
+        corpus_reader = create_mock_corpus_reader()
+
+        with pytest.raises(IOError):
+            path = os.path.join(target_folder, 'tmp')
+            corpus_reader.load(path)


### PR DESCRIPTION
Per our discussion in #89, I've added a simple path existence check to `base.py` to ensure an appropriate path is used in CorpusReader's `load` method. Additionally, I've added a unit test to `test_base.py` to confirm an `IOError` is thrown with invalid input.