### PR TITLE
do not call head if filesize is provided with headers

### DIFF
--- a/audiomate/corpus/io/swc.py
+++ b/audiomate/corpus/io/swc.py
@@ -13,9 +13,12 @@ from . import downloader
 
 
 URLS = {
-    'de': 'https://corpora.uni-hamburg.de/hzsk/de/islandora/object/file:swc-2.0_de-with-audio/datastream/TAR/de-with-audio.tar',
-    'en': 'https://corpora.uni-hamburg.de/hzsk/de/islandora/object/file:swc-2.0_en-with-audio/datastream/TAR/en-with-audio.tar',
-    'nl': 'https://corpora.uni-hamburg.de/hzsk/de/islandora/object/file:swc-2.0_nl-with-audio/datastream/TAR/nl-with-audio.tar'
+    'de': 'https://corpora.uni-hamburg.de/hzsk/de/islandora/object/file:swc-2.0_de-with-audio/datastream/'
+          'TAR/de-with-audio.tar',
+    'en': 'https://corpora.uni-hamburg.de/hzsk/de/islandora/object/file:swc-2.0_en-with-audio/datastream/'
+          'TAR/en-with-audio.tar',
+    'nl': 'https://corpora.uni-hamburg.de/hzsk/de/islandora/object/file:swc-2.0_nl-with-audio/datastream/'
+          'TAR/nl-with-audio.tar'
 }
 
 READER_NAME_PATTERN = re.compile(r'user_name\s+=\s+(.*?)\n')

--- a/audiomate/corpus/io/swc.py
+++ b/audiomate/corpus/io/swc.py
@@ -13,9 +13,9 @@ from . import downloader
 
 
 URLS = {
-    'de': 'https://www2.informatik.uni-hamburg.de/nats/pub/SWC/SWC_German.tar',
-    'en': 'https://www2.informatik.uni-hamburg.de/nats/pub/SWC/SWC_English.tar',
-    'nl': 'https://www2.informatik.uni-hamburg.de/nats/pub/SWC/SWC_Dutch.tar'
+    'de': 'https://corpora.uni-hamburg.de/hzsk/de/islandora/object/file:swc-2.0_de-with-audio/datastream/TAR/de-with-audio.tar',
+    'en': 'https://corpora.uni-hamburg.de/hzsk/de/islandora/object/file:swc-2.0_en-with-audio/datastream/TAR/en-with-audio.tar',
+    'nl': 'https://corpora.uni-hamburg.de/hzsk/de/islandora/object/file:swc-2.0_nl-with-audio/datastream/TAR/nl-with-audio.tar'
 }
 
 READER_NAME_PATTERN = re.compile(r'user_name\s+=\s+(.*?)\n')

--- a/audiomate/utils/download.py
+++ b/audiomate/utils/download.py
@@ -67,7 +67,10 @@ def download_file(url, target_path, num_threads=1):
             url
         ))
 
-    file_size = int(requests.head(url).headers['Content-Length'])
+    if r.headers['Content-Length']:
+        file_size = int(r.headers['Content-Length'])
+    else:
+        file_size = int(requests.head(url).headers['Content-Length'])
     bytes_loaded = 0
     bytes_since_last_log = 0
     logger.info('Download file from "%s" with size: %d B', url, file_size)


### PR DESCRIPTION
The download URL in `swc.py` is not valid anymore. The new server location does not support a HTTP head request. This patch is taking the file size from the previous GET and if the file size is known the head call is not executed.