### PR TITLE
ignoring reported.tsv from common voice

### DIFF
--- a/audiomate/corpus/io/common_voice.py
+++ b/audiomate/corpus/io/common_voice.py
@@ -97,7 +97,8 @@ class CommonVoiceReader(base.CorpusReader):
 
             # We don't want to include the invalidated files
             # since there maybe corrupt files
-            if basename != 'invalidated':
+            # reported utterances are also causing issue, e.g. empty entries
+            if basename != 'invalidated' and basename != 'reported':
                 subset_ids.append(basename)
 
         return subset_ids

--- a/audiomate/corpus/io/common_voice.py
+++ b/audiomate/corpus/io/common_voice.py
@@ -98,7 +98,7 @@ class CommonVoiceReader(base.CorpusReader):
             # We don't want to include the invalidated files
             # since there maybe corrupt files
             # reported utterances are also causing issue, e.g. empty entries
-            if basename != 'invalidated' and basename != 'reported':
+            if basename not in ('invalidated', 'reported'):
                 subset_ids.append(basename)
 
         return subset_ids


### PR DESCRIPTION
The reported.tsv contains invalid data, too. It cannot be processed.