### PR TITLE
Upgrade dependencies

### DIFF
--- a/audiomate/annotations/label_list.py
+++ b/audiomate/annotations/label_list.py
@@ -70,17 +70,17 @@ class LabelList:
 
     @property
     def labels(self):
-        """ Return list of labels. """
+        """Return list of labels."""
         return list(self)
 
     @property
     def start(self):
-        """ Return start of the earliest starting label (lower bound). """
+        """Return start of the earliest starting label (lower bound)."""
         return self.label_tree.begin()
 
     @property
     def end(self):
-        """ Return end of the lastly ending label (upper bound). """
+        """Return end of the lastly ending label (upper bound)."""
         return self.label_tree.end()
 
     @property
@@ -106,7 +106,7 @@ class LabelList:
         self.label_tree.addi(label.start, label.end, label)
 
     def addl(self, value, start=0.0, end=float('inf')):
-        """ Shortcut for ``add(Label(value, start, end))``. """
+        """Shortcut for ``add(Label(value, start, end))``."""
         self.add(Label(value, start=start, end=end))
 
     def update(self, labels):
@@ -173,7 +173,6 @@ class LabelList:
                 Label('b_label', 1.0, 2.0),
             ]
         """
-
         updated_labels = []
         all_intervals = self.label_tree.copy()
 
@@ -243,7 +242,6 @@ class LabelList:
             >>> ll.label_total_duration()
             {'a': 7.5 'b': 7.0}
         """
-
         durations = collections.defaultdict(float)
 
         for label in self:
@@ -269,8 +267,7 @@ class LabelList:
             >>> ll.label_values()
             ['a', 'b', 'c', 'd']
         """
-
-        all_labels = {l.value for l in self}
+        all_labels = {label.value for label in self}
         return sorted(all_labels)
 
     def label_count(self):
@@ -292,7 +289,6 @@ class LabelList:
             >>> ll.label_count()
             {'a': 3 'b': 2}
         """
-
         occurrences = collections.defaultdict(int)
 
         for label in self:
@@ -347,7 +343,6 @@ class LabelList:
             >>> ll.join(' - ')
             'a - b - c - d'
         """
-
         sorted_by_start = sorted(self.labels)
         concat_values = []
         last_label_end = None
@@ -388,7 +383,6 @@ class LabelList:
             >>> ll.tokenized(delimiter=' ', overlap_threshold=0.1)
             ['a', 'd', 'q', 'b', 'c', 'a', 'f', 'g']
         """
-
         sorted_by_start = sorted(self.labels)
         tokens = []
         last_label_end = None
@@ -463,7 +457,6 @@ class LabelList:
             >>> ll.labels_in_range(6.2, 10.1)
             [Label('b', 5.1, 8.9), Label('c', 7.2, 10.5)]
         """
-
         if fully_included:
             intervals = self.label_tree.envelop(start, end)
         else:
@@ -501,7 +494,6 @@ class LabelList:
             >>> next(ranges)
             (5.1, 7.2, [ < audiomate.annotations.label.Label at 0x1090484c8 > ])
         """
-
         tree_copy = self.label_tree.copy()
 
         # Remove labels not included
@@ -602,7 +594,6 @@ class LabelList:
                 Label('b', 0.4, 5.4)
             ]
         """
-
         if len(cutting_points) == 0:
             raise ValueError('At least one cutting-point is needed!')
 
@@ -654,7 +645,6 @@ class LabelList:
         Create a label-list with a single label
         containing the given value.
         """
-
         return LabelList(idx=idx, labels=[
             Label(value=value)
         ])
@@ -684,7 +674,6 @@ class LabelList:
                 Label('z', 0, inf),
             ]
         """
-
         ll = LabelList(idx=idx)
 
         for label_value in values:

--- a/audiomate/corpus/io/default.py
+++ b/audiomate/corpus/io/default.py
@@ -28,7 +28,7 @@ META_PATTERN = re.compile(LABEL_META_REGEX)
 
 
 class DefaultReader(base.CorpusReader):
-    """ Reads corpora in the Default format. """
+    """Reads corpora in the Default format."""
 
     @classmethod
     def type(cls):
@@ -145,9 +145,9 @@ class DefaultReader(base.CorpusReader):
     @staticmethod
     def read_labels(path, corpus):
 
-        for label_file in glob.glob(os.path.join(path, '{}_*.txt'.format(LABEL_FILE_PREFIX))):
+        for label_file in glob.glob(os.path.join(path, f'{LABEL_FILE_PREFIX}_*.txt')):
             file_name = os.path.basename(label_file)
-            key = file_name[len('{}_'.format(LABEL_FILE_PREFIX)):len(file_name) - len('.txt')]
+            key = file_name[len(f'{LABEL_FILE_PREFIX}_'):len(file_name) - len('.txt')]
 
             utterance_labels = collections.defaultdict(list)
 
@@ -197,7 +197,7 @@ class DefaultReader(base.CorpusReader):
                 container_path = entry[1]
                 key = entry[2]
 
-                if container_path in audio_containers.keys():
+                if container_path in audio_containers:
                     container = audio_containers[key]
                 else:
                     abs_path = os.path.abspath(os.path.join(base_path, container_path))
@@ -208,9 +208,9 @@ class DefaultReader(base.CorpusReader):
 
     @staticmethod
     def read_subviews(path, corpus):
-        for sv_file in glob.glob(os.path.join(path, '{}_*.txt'.format(SUBVIEW_FILE_PREFIX))):
+        for sv_file in glob.glob(os.path.join(path, f'{SUBVIEW_FILE_PREFIX}_*.txt')):
             file_name = os.path.basename(sv_file)
-            key = file_name[len('{}_'.format(SUBVIEW_FILE_PREFIX)):len(file_name) - len('.txt')]
+            key = file_name[len(f'{SUBVIEW_FILE_PREFIX}_'):len(file_name) - len('.txt')]
 
             with open(sv_file, 'r') as f:
                 content = f.read().strip()
@@ -220,7 +220,7 @@ class DefaultReader(base.CorpusReader):
 
 
 class DefaultWriter(base.CorpusWriter):
-    """ Writes corpora in the Default format. """
+    """Writes corpora in the Default format."""
 
     @classmethod
     def type(cls):
@@ -298,9 +298,8 @@ class DefaultWriter(base.CorpusWriter):
                 if issuer.native_language not in ['', None]:
                     issuer_data['native_language'] = issuer.native_language
 
-            elif type(issuer) is issuers.Artist:
-                if issuer.name not in ['', None]:
-                    issuer_data['name'] = issuer.name
+            elif type(issuer) is issuers.Artist and issuer.name not in ['', None]:
+                issuer_data['name'] = issuer.name
 
             data[issuer.idx] = issuer_data
 
@@ -340,23 +339,23 @@ class DefaultWriter(base.CorpusWriter):
         for utterance in corpus.utterances.values():
             for label_list_idx, label_list in utterance.label_lists.items():
                 utt_records = []
-                for l in label_list:
-                    start = l.start
-                    end = l.end
+                for label in label_list:
+                    start = label.start
+                    end = label.end
 
                     if end == float('inf'):
                         end = -1
 
-                    if len(l.meta) > 0:
-                        value = '{} [{}]'.format(l.value, json.dumps(l.meta, sort_keys=True))
+                    if len(label.meta) > 0:
+                        value = f'{label.value} [{json.dumps(label.meta, sort_keys=True)}]'
                         utt_records.append((utterance.idx, start, end, value))
                     else:
-                        utt_records.append((utterance.idx, start, end, l.value))
+                        utt_records.append((utterance.idx, start, end, label.value))
 
                 records[label_list_idx].extend(utt_records)
 
         for label_list_idx, label_list_records in records.items():
-            file_path = os.path.join(path, '{}_{}.txt'.format(LABEL_FILE_PREFIX, label_list_idx))
+            file_path = os.path.join(path, f'{LABEL_FILE_PREFIX}_{label_list_idx}.txt')
             textfile.write_separated_lines(file_path, label_list_records, separator=' ')
 
     @staticmethod
@@ -367,6 +366,6 @@ class DefaultWriter(base.CorpusWriter):
     @staticmethod
     def write_subviews(path, corpus):
         for name, sv in corpus.subviews.items():
-            sv_path = os.path.join(path, '{}_{}.txt'.format(SUBVIEW_FILE_PREFIX, name))
+            sv_path = os.path.join(path, f'{SUBVIEW_FILE_PREFIX}_{name}.txt')
             with open(sv_path, 'w') as f:
                 f.write(sv.serialize())

--- a/audiomate/corpus/io/kaldi.py
+++ b/audiomate/corpus/io/kaldi.py
@@ -219,7 +219,7 @@ class KaldiWriter(base.CorpusWriter):
 
                 target_path = os.path.join(
                     export_path,
-                    '{}.wav'.format(track.idx)
+                    f'{track.idx}.wav'
                 )
 
                 max_value = np.iinfo(np.int16).max
@@ -252,7 +252,7 @@ class KaldiWriter(base.CorpusWriter):
         if ext == '.wav':
             return abs_path
         else:
-            return 'sox {} -t wav - |'.format(abs_path)
+            return f'sox {abs_path} -t wav - |'
 
     def _write_segments(self, utterance_path, corpus):
         utterances = corpus.utterances.values()
@@ -309,7 +309,7 @@ class KaldiWriter(base.CorpusWriter):
 
             if self.main_label_list_idx in utterance.label_lists.keys():
                 label_list = utterance.label_lists[self.main_label_list_idx]
-                transcriptions[utt_idx] = ' '.join(l.value for l in label_list)
+                transcriptions[utt_idx] = ' '.join(label.value for label in label_list)
 
         textfile.write_separated_lines(
             text_path,
@@ -349,16 +349,15 @@ class KaldiWriter(base.CorpusWriter):
 
             fc.close()
 
-            ark_path = os.path.join(path, '{}.ark'.format(FEATS_FILE_NAME))
+            ark_path = os.path.join(path, f'{FEATS_FILE_NAME}.ark')
             ark_path = os.path.abspath(ark_path)
-            scp_path = os.path.join(path, '{}.scp'.format(FEATS_FILE_NAME))
+            scp_path = os.path.join(path, f'{FEATS_FILE_NAME}.scp')
 
             self.write_float_matrices(scp_path, ark_path, matrices)
 
     @staticmethod
     def feature_scp_generator(path):
-        """ Return a generator over all feature matrices defined in a scp. """
-
+        """Return a generator over all feature matrices defined in a scp."""
         scp_entries = textfile.read_key_value_lines(path, separator=' ')
 
         for utterance_id, rx_specifier in scp_entries.items():
@@ -366,8 +365,7 @@ class KaldiWriter(base.CorpusWriter):
 
     @staticmethod
     def read_float_matrix(rx_specifier):
-        """ Return float matrix as np array for the given rx specifier. """
-
+        """Return float matrix as np array for the given rx specifier."""
         path, offset = rx_specifier.strip().split(':', maxsplit=1)
         offset = int(offset)
         sample_format = 4
@@ -412,7 +410,7 @@ class KaldiWriter(base.CorpusWriter):
         if (self.prefix_utterances_with_speaker and
                 utt.issuer is not None and
                 not utt.idx.startswith(utt.issuer.idx)):
-            return '{}-{}'.format(utt.issuer.idx, utt.idx)
+            return f'{utt.issuer.idx}-{utt.idx}'
         else:
             return utt.idx
 
@@ -422,7 +420,6 @@ class KaldiWriter(base.CorpusWriter):
         Write the given dict matrices (utt-id/float ndarray)
         to the given scp and ark files.
         """
-
         scp_entries = []
 
         with open(ark_path, 'wb') as f:
@@ -433,7 +430,7 @@ class KaldiWriter(base.CorpusWriter):
                     msg = 'Features of utterance "{}" are have not type float 32!'
                     raise ValueError(msg.format(utterance_id))
 
-                f.write(('{} '.format(utterance_id)).encode('utf-8'))
+                f.write(f'{utterance_id} '.encode('utf-8'))
 
                 offset = f.tell()
 
@@ -449,11 +446,7 @@ class KaldiWriter(base.CorpusWriter):
                 )
                 flattened.tofile(f, sep='')
 
-                scp_entries.append('{} {}:{}'.format(
-                    utterance_id,
-                    ark_path,
-                    offset
-                ))
+                scp_entries.append(f'{utterance_id} {ark_path}:{offset}')
 
         with open(scp_path, 'w') as f:
             f.write('\n'.join(scp_entries))

--- a/audiomate/corpus/validation/label_list.py
+++ b/audiomate/corpus/validation/label_list.py
@@ -29,7 +29,7 @@ class UtteranceTranscriptionRatioValidator(base.Validator):
         self.num_threads = num_threads
 
     def name(self):
-        return 'Utterance-Transcription-Ratio ({})'.format(self.label_list_idx)
+        return f'Utterance-Transcription-Ratio ({self.label_list_idx})'
 
     def validate(self, corpus_to_validate):
         """
@@ -41,7 +41,6 @@ class UtteranceTranscriptionRatioValidator(base.Validator):
         Returns:
             InvalidItemsResult: Validation result.
         """
-
         with multiprocessing.pool.ThreadPool(self.num_threads) as p:
             func = functools.partial(
                 self.ratio_of_utterance,
@@ -77,10 +76,10 @@ class UtteranceTranscriptionRatioValidator(base.Validator):
     def ratio_of_utterance(self, utterance,  ll_idx):
         try:
             duration = utterance.duration
-            ll = utterance.label_lists[ll_idx]
+            labels = utterance.label_lists[ll_idx]
 
             # We count the characters of all labels
-            transcription = ' '.join(l.value for l in ll)
+            transcription = ' '.join(label.value for label in labels)
             num_chars = len(transcription.replace(' ', ''))
 
             char_per_sec = num_chars / duration
@@ -109,7 +108,7 @@ class LabelCountValidator(base.Validator):
         self.label_list_idx = label_list_idx
 
     def name(self):
-        return 'Label-Count ({})'.format(self.label_list_idx)
+        return f'Label-Count ({self.label_list_idx})'
 
     def validate(self, corpus_to_validate):
         """
@@ -128,9 +127,9 @@ class LabelCountValidator(base.Validator):
                 ll = utterance.label_lists[self.label_list_idx]
 
                 if len(ll) < self.min_number_of_labels:
-                    invalid_utterances[utterance.idx] = 'Only {} labels'.format(len(ll))
+                    invalid_utterances[utterance.idx] = f'Only {len(ll)} labels'
             else:
-                invalid_utterances[utterance.idx] = 'No label-list {}'.format(self.label_list_idx)
+                invalid_utterances[utterance.idx] = f'No label-list {self.label_list_idx}'
 
         passed = len(invalid_utterances) <= 0
         info = {
@@ -169,7 +168,6 @@ class LabelCoverageValidationResult(base.ValidationResult):
         Returns:
             str: String containing infos about the result
         """
-
         lines = [super(LabelCoverageValidationResult, self).get_report()]
 
         if len(self.uncovered_segments) > 0:
@@ -177,9 +175,9 @@ class LabelCoverageValidationResult(base.ValidationResult):
 
             for utt_idx, utt_segments in self.uncovered_segments.items():
                 if len(utt_segments) > 0:
-                    lines.append('\n{}'.format(utt_idx))
+                    lines.append(f'\n{utt_idx}')
                     sorted_items = sorted(utt_segments, key=lambda x: x[0])
-                    lines.extend(['    * {:10.2f}  -  {:10.2f}'.format(x[0], x[1]) for x in sorted_items])
+                    lines.extend([f'    * {x[0]:10.2f}  -  {x[1]:10.2f}' for x in sorted_items])
 
         return '\n'.join(lines)
 
@@ -201,7 +199,7 @@ class LabelCoverageValidator(base.Validator):
         self.threshold = threshold
 
     def name(self):
-        return 'Label-Coverage ({})'.format(self.label_list_idx)
+        return f'Label-Coverage ({self.label_list_idx})'
 
     def validate(self, corpus_to_validate):
         """
@@ -213,7 +211,6 @@ class LabelCoverageValidator(base.Validator):
         Returns:
             LabelCoverageValidationResult: Validation result.
         """
-
         uncovered_segments = {}
 
         for utterance in corpus_to_validate.utterances.values():
@@ -290,7 +287,6 @@ class LabelOverflowValidationResult(base.ValidationResult):
         Returns:
             str: String containing infos about the result
         """
-
         lines = [super(LabelOverflowValidationResult, self).get_report()]
 
         if len(self.overflow_segments) > 0:
@@ -298,9 +294,9 @@ class LabelOverflowValidationResult(base.ValidationResult):
 
             for utt_idx, utt_segments in self.overflow_segments.items():
                 if len(utt_segments) > 0:
-                    lines.append('\n{}'.format(utt_idx))
+                    lines.append(f'\n{utt_idx}')
                     sorted_items = sorted(utt_segments, key=lambda x: x[0])
-                    lines.extend(['    * {:10.2f}  -  {:10.2f} :  {}'.format(x[0], x[1], x[2]) for x in sorted_items])
+                    lines.extend([f'    * {x[0]:10.2f}  -  {x[1]:10.2f} :  {x[2]}' for x in sorted_items])
 
         return '\n'.join(lines)
 
@@ -321,7 +317,7 @@ class LabelOverflowValidator(base.Validator):
         self.threshold = threshold
 
     def name(self):
-        return 'Label-Overflow ({})'.format(self.label_list_idx)
+        return f'Label-Overflow ({self.label_list_idx})'
 
     def validate(self, corpus_to_validate):
         """
@@ -333,7 +329,6 @@ class LabelOverflowValidator(base.Validator):
         Returns:
             LabelOverflowValidationResult: Validation result.
         """
-
         overflow_segments = {}
 
         for utterance in corpus_to_validate.utterances.values():

--- a/audiomate/tracks/container.py
+++ b/audiomate/tracks/container.py
@@ -98,9 +98,9 @@ class ContainerTrack(track.Track):
 
             if sr is not None and sr != native_sr:
                 samples = librosa.core.resample(
-                    samples,
-                    native_sr,
-                    sr,
+                    y=samples,
+                    orig_sr=native_sr,
+                    target_sr=sr,
                     res_type='kaiser_best'
                 )
 

--- a/audiomate/tracks/container.py
+++ b/audiomate/tracks/container.py
@@ -17,6 +17,7 @@ class ContainerTrack(track.Track):
                    If ``None``, it is assumed it's the same
                    as ``idx``.
     """
+
     __slots__ = ['container', 'key']
 
     def __init__(self, idx, container, key=None):
@@ -45,24 +46,24 @@ class ContainerTrack(track.Track):
 
     @property
     def sampling_rate(self):
-        """ Return the sampling rate. """
+        """Return the sampling rate."""
         with self.container.open_if_needed(mode='r') as cnt:
             return cnt.get(self.key)[1]
 
     @property
     def num_channels(self):
-        """ Return the number of channels. """
+        """Return the number of channels."""
         return 1
 
     @property
     def num_samples(self):
-        """ Return the total number of samples. """
+        """Return the total number of samples."""
         with self.container.open_if_needed(mode='r') as cnt:
             return cnt.get(self.key)[0].shape[0]
 
     @property
     def duration(self):
-        """ Return the duration in seconds. """
+        """Return the duration in seconds."""
         with self.container.open_if_needed(mode='r') as cnt:
             samples, sr = cnt.get(self.key)
 

--- a/audiomate/utils/audio.py
+++ b/audiomate/utils/audio.py
@@ -1,7 +1,7 @@
 import librosa
 from audiomate.utils import audioread
 import numpy as np
-import scipy
+from scipy.io import wavfile
 
 
 def process_buffer(buffer, n_channels):
@@ -150,4 +150,4 @@ def write_wav(path, samples, sr=16000):
     """
     max_value = np.abs(np.iinfo(np.int16).min)
     data = (samples * max_value).astype(np.int16)
-    scipy.io.wavfile.write(path, sr, data)
+    wavfile.write(path, sr, data)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -79,7 +79,7 @@ release = '6.0.0'
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/docs/notes/changelog.rst
+++ b/docs/notes/changelog.rst
@@ -4,6 +4,17 @@ Changelog
 Next Version
 ------------
 
+v7.0.0
+------
+
+**Breaking Changes**
+
+* Drop support of Python 3.6 since EOL was `reached <https://peps.python.org/pep-0494/#lifespan>`_ in december 2021
+
+**Fixes**
+
+* Added a **name** column to the implementations table in the docs (:ref:`io_implementations`)
+
 v6.0.0
 ------
 

--- a/docs/reference/annotations.rst
+++ b/docs/reference/annotations.rst
@@ -27,3 +27,4 @@ Relabeling
 Exceptions
 ----------
 .. autoexception:: audiomate.annotations.relabeling.UnmappedLabelsException
+		:noindex:

--- a/docs/reference/io.rst
+++ b/docs/reference/io.rst
@@ -38,34 +38,35 @@ Implementations
 .. table:: Support for Reading and Writing by Format
 
 
-  ================================  ========  =====  =======
-  Format                            Download  Read   Write
-  ================================  ========  =====  =======
-  Acoustic Event Dataset            x         x
-  AudioMNIST                        x         x
-  Broadcast                                   x
-  Common Voice                      x         x
-  Default                                     x      x
-  ESC-50                            x         x
-  Free-Spoken-Digit-Dataset         x         x
-  Folder                                      x
-  Fluent Speech Commands Dataset              x
-  Google Speech Commands                      x
-  GTZAN                             x         x
-  Kaldi                                       x      x
-  LibriSpeech                       x         x
-  Mozilla DeepSpeech                                 x
-  MUSAN                             x         x
-  M-AILABS Speech Dataset           x         x
-  LITIS Rouen Audio scene dataset   x         x
-  Spoken Wikipedia Corpora          x         x
-  Tatoeba                           x         x
-  TIMIT                                       x
-  TUDA German Distant Speech        x         x
-  Urbansound8k                                x
-  VoxForge                          x         x
-  Wav2Letter                                         x
-  ================================  ========  =====  =======
+  ================================  ========  =====  ======= ==================
+  Format                            Download  Read   Write   Key (for reading and writing)
+  ================================  ========  =====  ======= ==================
+  Acoustic Event Dataset            x         x              aed
+  AudioMNIST                        x         x              audio-mnist
+  Broadcast                                   x              broadcast
+  Common Voice                      x         x              common-voice
+  Default                                     x      x       default
+  ESC-50                            x         x              esc-50
+  Free-Spoken-Digit-Dataset         x         x              free-spoken-digits
+  Folder                                      x              folder
+  Fluent Speech Commands Dataset              x              fluent-speech
+  Google Speech Commands                      x              speech-commands
+  GTZAN                             x         x              gtzan
+  Kaldi                                       x      x       kaldi
+  LibriSpeech                       x         x              librispeech
+  Mozilla DeepSpeech                                 x       mozilla-deepspeech
+  MUSAN                             x         x              musan
+  M-AILABS Speech Dataset           x         x              mailabs
+  NVIDIA Jasper                                      x       nvidia-jasper
+  LITIS Rouen Audio scene dataset   x         x              rouen
+  Spoken Wikipedia Corpora          x         x              swc
+  Tatoeba                           x         x              tatoeba
+  TIMIT                                       x              timit
+  TUDA German Distant Speech        x         x              tuda
+  Urbansound8k                                x              urbansound8k
+  VoxForge                          x         x              voxforge
+  Wav2Letter                                         x       wav2letter
+  ================================  ========  =====  ======= ==================
 
 Acoustic Event Dataset
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/setup.py
+++ b/setup.py
@@ -7,45 +7,45 @@ from setuptools import setup
 # Dependencies
 ##################################################
 
-PYTEST_VERSION_ = '5.3.5'
+PYTEST_VERSION_ = '7.1.2'
 
 # Packages required in 'production'
 REQUIRED = [
-    'audioread == 2.1.8',
-    'numpy == 1.18.1',
-    'scipy == 1.4.1',
-    'librosa == 0.7.2',
-    'h5py == 2.10.0',
-    'networkx == 2.4',
-    'requests == 2.23.0',
-    'intervaltree == 3.0.2',
-    'sox == 1.3.7',
-    'PGet == 0.5.0',
-    'numba == 0.49.1'
+    'audioread == 2.1.9',
+    'numpy == 1.21.6',
+    'scipy == 1.7.3',
+    'librosa == 0.9.2',
+    'h5py == 3.7.0',
+    'networkx == 2.6.3',
+    'requests == 2.28.1',
+    'intervaltree == 3.1.0',
+    'sox == 1.4.1',
+    'PGet == 0.5.1',
+    'numba == 0.56.0'
 ]
 
 # Packages required for dev/ci enrionment
 EXTRAS = {
     'dev': [
-        'click==7.0',
-        'pytest==%s' % (PYTEST_VERSION_,),
-        'pytest-runner==5.2',
-        'pytest-cov==2.8.1',
-        'requests_mock==1.7.0',
-        'Sphinx==2.4.4',
-        'sphinx-rtd-theme==0.4.3',
-        'pytest-benchmark==3.2.3',
+        'click == 8.1.3',
+        'pytest == %s' % (PYTEST_VERSION_,),
+        'pytest-runner == 6.0',
+        'pytest-cov == 3.0.0',
+        'requests_mock == 1.9.3',
+        'Sphinx == 5.1.1',
+        'sphinx-rtd-theme == 1.0.0',
+        'pytest-benchmark == 3.4.1'
     ],
     'ci': [
-        'flake8==3.7.9',
-        'flake8-quotes==2.1.1'
+        'flake8 == 4.0.1',
+        'flake8-quotes == 3.3.1'
     ],
 }
 
 # Packages required for testing
 TESTS = [
-    'pytest==%s' % (PYTEST_VERSION_,),
-    'requests_mock==1.7.0'
+    'pytest == %s' % (PYTEST_VERSION_,),
+    'requests_mock == 1.9.3'
 ]
 
 ##################################################
@@ -80,9 +80,10 @@ setup(name='audiomate',
       classifiers=[
           'Intended Audience :: Science/Research',
           'License :: OSI Approved :: MIT License',
-          'Programming Language :: Python :: 3.6',
           'Programming Language :: Python :: 3.7',
           'Programming Language :: Python :: 3.8',
+          'Programming Language :: Python :: 3.9',
+          'Programming Language :: Python :: 3.10',
           'Topic :: Scientific/Engineering :: Human Machine Interfaces'
       ],
       keywords='audio music sound corpus dataset',

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ REQUIRED = [
 EXTRAS = {
     'dev': [
         'click == 8.1.3',
-        'pytest == %s' % (PYTEST_VERSION_,),
+        f"pytest == {PYTEST_VERSION_}",
         'pytest-runner == 6.0',
         'pytest-cov == 3.0.0',
         'requests_mock == 1.9.3',
@@ -44,7 +44,7 @@ EXTRAS = {
 
 # Packages required for testing
 TESTS = [
-    'pytest == %s' % (PYTEST_VERSION_,),
+    f"pytest == {PYTEST_VERSION_}",
     'requests_mock == 1.9.3'
 ]
 

--- a/tests/encoding/test_frame_based.py
+++ b/tests/encoding/test_frame_based.py
@@ -115,7 +115,7 @@ class TestFrameOrdinalEncoder:
                                            sr=16000)
 
         actual = enc.encode_utterance(ds.utterances['utt-6'])
-        expected = np.array([0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 0, 0]).astype(np.int)
+        expected = np.array([0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 0, 0]).astype(int)
 
         assert np.array_equal(expected, actual)
 
@@ -134,7 +134,7 @@ class TestFrameOrdinalEncoder:
                                            sr=16000)
 
         actual = enc.encode_utterance(utt)
-        expected = np.array([0, 0, 0, 0, 1, 1, 1]).astype(np.int)
+        expected = np.array([0, 0, 0, 0, 1, 1, 1]).astype(int)
 
         assert np.array_equal(expected, actual)
 
@@ -153,6 +153,6 @@ class TestFrameOrdinalEncoder:
                                            sr=16000)
 
         actual = enc.encode_utterance(utt)
-        expected = np.array([1, 1, 0, 0]).astype(np.int)
+        expected = np.array([1, 1, 0, 0]).astype(int)
 
         assert np.array_equal(expected, actual)

--- a/tests/processing/test_base.py
+++ b/tests/processing/test_base.py
@@ -1,14 +1,12 @@
 import os
 
 import numpy as np
-from audiomate.utils import audio
 import h5py
 
 import pytest
 
-from audiomate import tracks
-from audiomate import containers
-from audiomate import processing
+from audiomate import tracks, containers, processing
+from audiomate.utils import audio
 
 from tests import resources
 

--- a/tests/processing/test_base.py
+++ b/tests/processing/test_base.py
@@ -1,7 +1,7 @@
 import os
 
 import numpy as np
-import librosa
+from audiomate.utils import audio
 import h5py
 
 import pytest
@@ -65,7 +65,7 @@ class TestProcessor:
         wav_path = os.path.join(tmpdir.strpath, 'file.wav')
         wav_content = np.random.random(22)
 
-        librosa.output.write_wav(wav_path, wav_content, 4)
+        audio.write_wav(wav_path, wav_content, 4)
         file_track = tracks.FileTrack('idx', wav_path)
 
         processed = processor.process_track(file_track, frame_size=4, hop_size=2)
@@ -85,7 +85,7 @@ class TestProcessor:
         wav_path = os.path.join(tmpdir.strpath, 'file.wav')
         wav_content = np.random.random(22)
 
-        librosa.output.write_wav(wav_path, wav_content, 16000)
+        audio.write_wav(wav_path, wav_content, 16000)
         file_track = tracks.FileTrack('idx', wav_path)
 
         processed = processor.process_track(file_track, frame_size=4096, hop_size=2048, sr=16000)
@@ -103,7 +103,7 @@ class TestProcessor:
         wav_path = os.path.join(tmpdir.strpath, 'file.wav')
         wav_content = np.random.random(0)
 
-        librosa.output.write_wav(wav_path, wav_content, 16000)
+        audio.write_wav(wav_path, wav_content, 16000)
         file_track = tracks.FileTrack('idx', wav_path)
 
         with pytest.raises(ValueError):
@@ -113,7 +113,7 @@ class TestProcessor:
         wav_path = os.path.join(tmpdir.strpath, 'file.wav')
         wav_content = np.random.random(22)
 
-        librosa.output.write_wav(wav_path, wav_content, 4)
+        audio.write_wav(wav_path, wav_content, 4)
         file_track = tracks.FileTrack('idx', wav_path)
 
         processed = processor.process_track(file_track, frame_size=4, hop_size=2, sr=2)
@@ -134,7 +134,7 @@ class TestProcessor:
         wav_path = os.path.join(tmpdir.strpath, 'file.wav')
         wav_content = np.random.random(174)
 
-        librosa.output.write_wav(wav_path, wav_content, 16000)
+        audio.write_wav(wav_path, wav_content, 16000)
         track = tracks.FileTrack('idx', wav_path)
 
         chunks = list(processor.process_track_online(track, frame_size=20, hop_size=10, chunk_size=8))
@@ -154,7 +154,7 @@ class TestProcessor:
         wav_path = os.path.join(tmpdir.strpath, 'file.wav')
         wav_content = np.random.random(170)
 
-        librosa.output.write_wav(wav_path, wav_content, 16000)
+        audio.write_wav(wav_path, wav_content, 16000)
         track = tracks.FileTrack('idx', wav_path)
 
         chunks = list(processor.process_track_online(track, frame_size=20, hop_size=10, chunk_size=8))

--- a/tests/tracks/test_file.py
+++ b/tests/tracks/test_file.py
@@ -3,6 +3,7 @@ import os
 import pytest
 import numpy as np
 import librosa
+from audiomate.utils import audio
 
 from audiomate import tracks
 
@@ -131,7 +132,7 @@ class TestFile:
         wav_path = os.path.join(tmpdir.strpath, 'file.wav')
         wav_content = np.random.random(10044)
 
-        librosa.output.write_wav(wav_path, wav_content, 16000)
+        audio.write_wav(wav_path, wav_content, 16000)
         file_obj = tracks.FileTrack('some_idx', wav_path)
 
         data = list(file_obj.read_frames(frame_size=400, hop_size=160))

--- a/tests/utils/test_audio.py
+++ b/tests/utils/test_audio.py
@@ -1,7 +1,6 @@
 import os
 
 import numpy as np
-import librosa
 
 from audiomate import tracks
 from audiomate.utils import audio
@@ -10,7 +9,8 @@ from audiomate.utils import audio
 def test_read_blocks(tmpdir):
     wav_path = os.path.join(tmpdir.strpath, 'file.wav')
     wav_content = np.random.random(10000)
-    librosa.output.write_wav(wav_path, wav_content, 16000)
+
+    audio.write_wav(wav_path, wav_content, 16000)
 
     blocks = list(audio.read_blocks(wav_path, buffer_size=1000))
 
@@ -21,7 +21,7 @@ def test_read_blocks(tmpdir):
 def test_read_blocks_with_start_end(tmpdir):
     wav_path = os.path.join(tmpdir.strpath, 'file.wav')
     wav_content = np.random.random(10000)
-    librosa.output.write_wav(wav_path, wav_content, 16000)
+    audio.write_wav(wav_path, wav_content, 16000)
 
     blocks = list(audio.read_blocks(wav_path, start=0.1, end=0.3, buffer_size=1000))
 
@@ -32,7 +32,7 @@ def test_read_blocks_with_start_end(tmpdir):
 def test_read_frames(tmpdir):
     wav_path = os.path.join(tmpdir.strpath, 'file.wav')
     wav_content = np.random.random(10044)
-    librosa.output.write_wav(wav_path, wav_content, 16000)
+    audio.write_wav(wav_path, wav_content, 16000)
 
     data = list(audio.read_frames(wav_path, frame_size=400, hop_size=160))
     frames = np.array([x[0] for x in data])
@@ -50,7 +50,7 @@ def test_read_frames(tmpdir):
 def test_read_frames_matches_length(tmpdir):
     wav_path = os.path.join(tmpdir.strpath, 'file.wav')
     wav_content = np.random.random(10000)
-    librosa.output.write_wav(wav_path, wav_content, 16000)
+    audio.write_wav(wav_path, wav_content, 16000)
 
     data = list(audio.read_frames(wav_path, frame_size=400, hop_size=160))
     frames = np.array([x[0] for x in data])


### PR DESCRIPTION
This PR deprecates Python 3.6, since this version has reached EOL (see link in changelog).

Python 3.9 and 3.10 are now supported versions. 
All dependencies are upgraded to versions between Python 3.7 and 3.10.

Some flake8 fixes are included.

`flake8`, `pytest`, `pytest bench` and  `cd docs && make html` was successfully executed with all now supported Python versions (3.7.13, 3.8.13, 3.9.13, 3.10.4). The benchmarks where not compared!

The `audiomate.corpus.io` of the docs has gotten a bit bigger after upgrading Sphinx to the latest version.  
The bullets of ordered lists were hidden, but visible again after also upgrading `sphinx-rtd-theme` to the latest version.

I didn't red the whole documentation 4 times (xD), but a quick look at all pages makes me feel like the docs looks fine.

This PR also fixes #83, though maybe a reference from the README could be added.

One Problem I observed with Python 3.7:
When installing the dev deps with `pip install -e .[dev]` and afterwards installing the ci deps with `pip install -e .[ci]` (or vice versa) an error message is shown:
```bash
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
flake8 4.0.1 requires importlib-metadata<4.3; python_version < "3.8", but you have importlib-metadata 4.12.0 which is incompatible.
```
In a ci environment this could be a problem when testing with pytest (Python version 3.7) and then linting with flake8. 
During development this seems not to be a problem (flake8 and also pytest are running successfully despite the error).

When linting and testing (and the corresponding `pip install`) are executed in 2 different stages, the build should be run successfully since the error is only shown when `.[ci]` and `.[dev]` are executed consecutively.